### PR TITLE
add minimal_zgui_glfw_gl sample

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -90,8 +90,11 @@ fn packagesCrossPlatform(b: *std.Build, options: Options) void {
     znoise_pkg = znoise.package(b, target, optimize, .{});
     zstbi_pkg = zstbi.package(b, target, optimize, .{});
     zbullet_pkg = zbullet.package(b, target, optimize, .{});
-    zgui_pkg = zgui.package(b, target, optimize, .{
+    zgui_glfw_wgpu_pkg = zgui.package(b, target, optimize, .{
         .options = .{ .backend = .glfw_wgpu },
+    });
+    zgui_glfw_gl_pkg = zgui.package(b, target, optimize, .{
+        .options = .{ .backend = .glfw_opengl3 },
     });
     zgpu_pkg = zgpu.package(b, target, optimize, .{
         .options = .{ .uniforms_buffer_size = 4 * 1024 * 1024 },
@@ -162,6 +165,7 @@ fn samplesCrossPlatform(b: *std.Build, options: Options) void {
     const audio_experiments_wgpu = @import("samples/audio_experiments_wgpu/build.zig");
     const gui_test_wgpu = @import("samples/gui_test_wgpu/build.zig");
     const minimal_zgpu_zgui = @import("samples/minimal_zgpu_zgui/build.zig");
+    const minimal_zgui_glfw_gl = @import("samples/minimal_zgui_glfw_gl/build.zig");
     const instanced_pills_wgpu = @import("samples/instanced_pills_wgpu/build.zig");
     const layers_wgpu = @import("samples/layers_wgpu/build.zig");
     const gamepad_wgpu = @import("samples/gamepad_wgpu/build.zig");
@@ -174,6 +178,7 @@ fn samplesCrossPlatform(b: *std.Build, options: Options) void {
     install(b, textured_quad_wgpu.build(b, options), "textured_quad_wgpu");
     install(b, gui_test_wgpu.build(b, options), "gui_test_wgpu");
     install(b, minimal_zgpu_zgui.build(b, options), "minimal_zgpu_zgui");
+    install(b, minimal_zgui_glfw_gl.build(b, options), "minimal_zgui_glfw_gl");
     install(b, physically_based_rendering_wgpu.build(b, options), "physically_based_rendering_wgpu");
     install(b, instanced_pills_wgpu.build(b, options), "instanced_pills_wgpu");
     install(b, gamepad_wgpu.build(b, options), "gamepad_wgpu");
@@ -249,7 +254,8 @@ pub var zmesh_pkg: zmesh.Package = undefined;
 pub var zglfw_pkg: zglfw.Package = undefined;
 pub var zstbi_pkg: zstbi.Package = undefined;
 pub var zbullet_pkg: zbullet.Package = undefined;
-pub var zgui_pkg: zgui.Package = undefined;
+pub var zgui_glfw_wgpu_pkg: zgui.Package = undefined;
+pub var zgui_glfw_gl_pkg: zgui.Package = undefined;
 pub var zgpu_pkg: zgpu.Package = undefined;
 pub var ztracy_pkg: ztracy.Package = undefined;
 pub var zphysics_pkg: zphysics.Package = undefined;

--- a/libs/zgui/src/backend_glfw_opengl.zig
+++ b/libs/zgui/src/backend_glfw_opengl.zig
@@ -22,9 +22,12 @@ pub fn deinit() void {
     ImGui_ImplOpenGL3_Shutdown();
 }
 
-pub fn newFrame() void {
+pub fn newFrame(fb_width: u32, fb_height: u32) void {
     ImGui_ImplGlfw_NewFrame();
     ImGui_ImplOpenGL3_NewFrame();
+
+    gui.io.setDisplaySize(@as(f32, @floatFromInt(fb_width)), @as(f32, @floatFromInt(fb_height)));
+    gui.io.setDisplayFramebufferScale(1.0, 1.0);
 
     gui.newFrame();
 }

--- a/samples/audio_experiments_wgpu/build.zig
+++ b/samples/audio_experiments_wgpu/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/bullet_physics_test_wgpu/build.zig
+++ b/samples/bullet_physics_test_wgpu/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/gamepad_wgpu/build.zig
+++ b/samples/gamepad_wgpu/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/gui_test_wgpu/build.zig
+++ b/samples/gui_test_wgpu/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/instanced_pills_wgpu/build.zig
+++ b/samples/instanced_pills_wgpu/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/layers_wgpu/build.zig
+++ b/samples/layers_wgpu/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/minimal_zgui_glfw_gl/README.md
+++ b/samples/minimal_zgui_glfw_gl/README.md
@@ -1,0 +1,3 @@
+## minimal zgui with glfw gl3 backend
+
+This minimal sample has a button that prints a message to the console when pressed.

--- a/samples/minimal_zgui_glfw_gl/build.zig
+++ b/samples/minimal_zgui_glfw_gl/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
 
-const demo_name = "minimal_zgpu_zgui";
+const demo_name = "minimal_zgui_glfw_gl";
 const content_dir = demo_name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
@@ -13,12 +13,12 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_gl_pkg;
+    const zopengl_pkg = @import("../../build.zig").zopengl_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
 
     zgui_pkg.link(exe);
-    zgpu_pkg.link(exe);
+    zopengl_pkg.link(exe);
     zglfw_pkg.link(exe);
 
     const exe_options = b.addOptions();

--- a/samples/minimal_zgui_glfw_gl/minimal_zgui_glfw_gl_content/Roboto-Medium.ttf
+++ b/samples/minimal_zgui_glfw_gl/minimal_zgui_glfw_gl_content/Roboto-Medium.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559132c89ad51d8a2ba5b171887a44a7ba93776e205f553573de228e64b45f8
+size 162588

--- a/samples/minimal_zgui_glfw_gl/src/minimal_zgui_glfw_gl.zig
+++ b/samples/minimal_zgui_glfw_gl/src/minimal_zgui_glfw_gl.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+
+const zgui = @import("zgui");
+const glfw = @import("zglfw");
+const gl = @import("zopengl");
+
+const content_dir = @import("build_options").content_dir;
+const window_title = "zig-gamedev: minimal zgpu glfw opengl3";
+
+pub fn main() !void {
+    try glfw.init();
+    defer glfw.terminate();
+
+    // Change current working directory to where the executable is located.
+    {
+        var buffer: [1024]u8 = undefined;
+        const path = std.fs.selfExeDirPath(buffer[0..]) catch ".";
+        std.os.chdir(path) catch {};
+    }
+
+    const gl_major = 4;
+    const gl_minor = 0;
+    glfw.windowHintTyped(.context_version_major, gl_major);
+    glfw.windowHintTyped(.context_version_minor, gl_minor);
+    glfw.windowHintTyped(.opengl_profile, .opengl_core_profile);
+    glfw.windowHintTyped(.opengl_forward_compat, true);
+    glfw.windowHintTyped(.client_api, .opengl_api);
+    glfw.windowHintTyped(.doublebuffer, true);
+
+    const window = try glfw.Window.create(800, 500, window_title, null);
+    defer window.destroy();
+    window.setSizeLimits(400, 400, -1, -1);
+
+    glfw.makeContextCurrent(window);
+    glfw.swapInterval(1);
+
+    try gl.loadCoreProfile(glfw.getProcAddress, gl_major, gl_minor);
+
+    var gpa_state = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa_state.deinit();
+    const gpa = gpa_state.allocator();
+
+    zgui.init(gpa);
+    defer zgui.deinit();
+
+    const scale_factor = scale_factor: {
+        const scale = window.getContentScale();
+        break :scale_factor @max(scale[0], scale[1]);
+    };
+    _ = zgui.io.addFontFromFile(
+        content_dir ++ "Roboto-Medium.ttf",
+        std.math.floor(16.0 * scale_factor),
+    );
+
+    zgui.getStyle().scaleAllSizes(scale_factor);
+
+    zgui.backend.init(window);
+    defer zgui.backend.deinit();
+
+    while (!window.shouldClose() and window.getKey(.escape) != .press) {
+        glfw.pollEvents();
+
+        gl.clearBufferfv(gl.COLOR, 0, &[_]f32{ 0, 0, 0, 1.0 });
+
+        const fb_size = window.getFramebufferSize();
+
+        zgui.backend.newFrame(@intCast(fb_size[0]), @intCast(fb_size[1]));
+
+        // Set the starting window position and size to custom values
+        zgui.setNextWindowPos(.{ .x = 20.0, .y = 20.0, .cond = .first_use_ever });
+        zgui.setNextWindowSize(.{ .w = -1.0, .h = -1.0, .cond = .first_use_ever });
+
+        if (zgui.begin("My window", .{})) {
+            if (zgui.button("Press me!", .{ .w = 200.0 })) {
+                std.debug.print("Button pressed\n", .{});
+            }
+        }
+        zgui.end();
+
+        zgui.backend.draw();
+
+        window.swapBuffers();
+    }
+}

--- a/samples/monolith/build.zig
+++ b/samples/monolith/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/physically_based_rendering_wgpu/build.zig
+++ b/samples/physically_based_rendering_wgpu/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/physics_test_wgpu/build.zig
+++ b/samples/physics_test_wgpu/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/procedural_mesh_wgpu/build.zig
+++ b/samples/procedural_mesh_wgpu/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/textured_quad_wgpu/build.zig
+++ b/samples/textured_quad_wgpu/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;

--- a/samples/triangle_wgpu/build.zig
+++ b/samples/triangle_wgpu/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_wgpu_pkg;
     const zmath_pkg = @import("../../build.zig").zmath_pkg;
     const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
     const zglfw_pkg = @import("../../build.zig").zglfw_pkg;


### PR DESCRIPTION
`zig build minimal_zgui_glfw_gl-run`

~~Currently not working. I think zopengl's C exports are broken~~

<details>
  <summary>lldb output</summary>

```
(lldb) target create "./zig-out/bin/minimal_zgui_glfw_gl"
Current executable set to '/Users/chris/Desktop/zig-gamedev/zig-out/bin/minimal_zgui_glfw_gl' (x86_64).
(lldb) run
Process 13338 launched: '/Users/chris/Desktop/zig-gamedev/zig-out/bin/minimal_zgui_glfw_gl' (x86_64)
2023-10-03 23:27:56.698007+0100 minimal_zgui_glfw_gl[13338:421632] SecTaskLoadEntitlements failed error=22 cs_flags=20, pid=13338
2023-10-03 23:27:56.698110+0100 minimal_zgui_glfw_gl[13338:421632] SecTaskCopyDebugDescription: minimal_zgui_glf[13338]/0#-1 LF=0
2023-10-03 23:27:57.477379+0100 minimal_zgui_glfw_gl[13338:421632] [Window] Warning: Window GLFWWindow 0x100f07ae0 ordered front from a non-active application and may order beneath the active application's windows.
2023-10-03 23:27:57.482626+0100 minimal_zgui_glfw_gl[13338:421632] [Window] Warning: Window GLFWWindow 0x100f07ae0 ordered front from a non-active application and may order beneath the active application's windows.
Process 13338 stopped
* thread zig-gamedev/zig-gamedev#1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=2, address=0x10079b298)
    frame #0: 0x000000010079b298 minimal_zgui_glfw_gl`glGetIntegerv
minimal_zgui_glfw_gl`glGetIntegerv:
->  0x10079b298 <+0>: rep    jns	0x10079b2e3           ; glViewport + 3
    0x10079b29b <+3>: subl   $0x7ffa, %eax             ; imm = 0x7FFA 
```

</details>